### PR TITLE
Quote S3 Path with single quotes

### DIFF
--- a/lib/AWS/CLIWrapper.pm
+++ b/lib/AWS/CLIWrapper.pm
@@ -122,7 +122,7 @@ sub _execute {
     my @cmd = ('aws', @{$self->{opt}}, $service, $operation);
     if (ref($_[0]) eq 'ARRAY') {
         # for s3 sync FROM TO
-        push @cmd, @{ shift @_ };
+        push @cmd, map { qq{'$_'} } @{ shift @_ };
     }
     my($param, %opt) = @_;
 


### PR DESCRIPTION
S3 related arguments are not quoted at all so the command fails if it contains spaces.
This patch escapes the string with single quotes.

Actually this is not sufficient because it gets broken when a string has a single quote itself. To address this I think we should either use String::ShellQuote or use a regexp to escape every special character with backslashes. However, I decided to use the same measure used in param2opt.
