### PR TITLE
write stdout/stderr message in debug mode

### DIFF
--- a/lib/AWS/CLIWrapper.pm
+++ b/lib/AWS/CLIWrapper.pm
@@ -209,7 +209,11 @@ sub _execute {
             $self->json->decode_prefix($json);
         };
         if ($@) {
-            warn $@ if $ENV{AWSCLI_DEBUG};
+            if ($ENV{AWSCLI_DEBUG}) {
+                warn $@;
+                warn qq|stdout: "$ret->{stdout}"|;
+                warn qq|err_msg: "$ret->{err_msg}"|;
+            }
             return $json || 'success';
         }
         return $ret;


### PR DESCRIPTION
`AWS::CLIWrapper` does not have a way to write stderr from `awscli`.
In debugging mode stderr message should be written along with stdout message.
