### PR TITLE
support ec2 wait

### DIFF
--- a/lib/AWS/CLIWrapper.pm
+++ b/lib/AWS/CLIWrapper.pm
@@ -124,6 +124,9 @@ sub _execute {
     my $service = shift;
     my $operation = shift;
     my @cmd = ('aws', @{$self->{opt}}, $service, $operation);
+    if ($service eq 'ec2' && $operation eq 'wait') {
+        push(@cmd, shift @_);
+    }
     if (ref($_[0]) eq 'ARRAY') {
         # for s3 sync FROM TO
         push @cmd, @{ shift @_ };


### PR DESCRIPTION
http://docs.aws.amazon.com/cli/latest/reference/ec2/wait/index.html のサポートを追加

```
my $ret = $awscli->ec2(
    'wait' => 'instance-status-ok' => {
        instance_ids => [ 'i-xxxxxxxx' ],
    },
);
```