### PR TITLE
Added github repo and min perl version to dist metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for AWS::CLIWrapper
 
 1.10  2015-10-??
         - Specified min perl version both in module and dist metadata
+        - Added github repo to dist metadata
 
 1.09  2015-10-02
     [IMPROVEMENTS]

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for AWS::CLIWrapper
 
+1.10  2015-10-??
+        - Specified min perl version both in module and dist metadata
+
 1.09  2015-10-02
     [IMPROVEMENTS]
         - Support ec2 wait (PR #9 by @negachov)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,6 +26,16 @@ my %WriteMakefileArgs = (
     },
     "VERSION_FROM" => "lib/AWS/CLIWrapper.pm",
     "MIN_PERL_VERSION" => 5.008001,
+    "META_MERGE" => {
+        'meta-spec' => { version => 2 },
+        resources => {
+            repository  => {
+                type => 'git',
+                web  => 'https://github.com/hirose31/AWS-CLIWrapper',
+                url  => 'https://github.com/hirose31/AWS-CLIWrapper.git',
+            },
+        },
+    },
     "test" => {
         "TESTS" => "t/*.t"
     }
@@ -55,6 +65,9 @@ unless ( eval { ExtUtils::MakeMaker->VERSION(6.56) } ) {
         }
     }
 }
+
+delete $WriteMakefileArgs{META_MERGE}
+    unless eval { ExtUtils::MakeMaker->VERSION(6.48) };
 
 delete $WriteMakefileArgs{MIN_PERL_VERSION}
     unless eval { ExtUtils::MakeMaker->VERSION(6.48) };

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,6 +25,7 @@ my %WriteMakefileArgs = (
         "Test::More" => 0
     },
     "VERSION_FROM" => "lib/AWS/CLIWrapper.pm",
+    "MIN_PERL_VERSION" => 5.008001,
     "test" => {
         "TESTS" => "t/*.t"
     }
@@ -54,6 +55,9 @@ unless ( eval { ExtUtils::MakeMaker->VERSION(6.56) } ) {
         }
     }
 }
+
+delete $WriteMakefileArgs{MIN_PERL_VERSION}
+    unless eval { ExtUtils::MakeMaker->VERSION(6.48) };
 
 delete $WriteMakefileArgs{CONFIGURE_REQUIRES}
     unless eval { ExtUtils::MakeMaker->VERSION(6.52) };

--- a/lib/AWS/CLIWrapper.pm
+++ b/lib/AWS/CLIWrapper.pm
@@ -1,9 +1,10 @@
 package AWS::CLIWrapper;
 
+use 5.008001;
 use strict;
 use warnings;
 
-our $VERSION = '1.09';
+our $VERSION = '1.10';
 
 use version;
 use JSON 2;


### PR DESCRIPTION
Hi Masaaki-san,

This adds your github repo to the dist's metadata. This will make the repo appear in the sidebar on MetaCPAN, and also will make it a candidate for assigning in the [CPAN Pull Request Challenge](http://cpan-prc.org).

I also added the min perl version to the dist metadata.

Cheers,
Neil