### PR TITLE
Make AWS::CLIWrapper take explicit awscli executable path

### DIFF
--- a/lib/AWS/CLIWrapper.pm
+++ b/lib/AWS/CLIWrapper.pm
@@ -31,9 +31,15 @@ sub new {
     my $self = bless {
         opt  => \@opt,
         json => JSON->new,
+        awscli_path => $param{awscli_path} // 'aws',
     }, $class;
 
     return $self;
+}
+
+sub awscli_path {
+    my ($self) = @_;
+    return $self->{awscli_path};
 }
 
 sub awscli_version {
@@ -124,7 +130,7 @@ sub _execute {
     my $self    = shift;
     my $service = shift;
     my $operation = shift;
-    my @cmd = ('aws', @{$self->{opt}}, $service, $operation);
+    my @cmd = ($self->awscli_path, @{$self->{opt}}, $service, $operation);
     if ($service eq 'ec2' && $operation eq 'wait') {
         push(@cmd, shift @_);
     }

--- a/lib/AWS/CLIWrapper.pm
+++ b/lib/AWS/CLIWrapper.pm
@@ -43,9 +43,11 @@ sub awscli_path {
 }
 
 sub awscli_version {
+    my ($self) = @_;
     unless (defined $AWSCLI_VERSION) {
         $AWSCLI_VERSION = do {
-            my $vs = qx(aws --version 2>&1) || '';
+            my $awscli_path = $self->awscli_path;
+            my $vs = qx($awscli_path --version 2>&1) || '';
             my $v;
             if ($vs =~ m{/([0-9.]+)\s}) {
                 $v = $1;
@@ -144,7 +146,7 @@ sub _execute {
         # compat: ec2 run-instances
         # >= 0.14.0 : --count N or --count MIN:MAX
         # <  0.14.0 : --min-count N and --max-count N
-        if (__PACKAGE__->awscli_version >= 0.14.0) {
+        if ($self->awscli_version >= 0.14.0) {
             my($min,$max) = (1,1);
             for my $hk (keys %$param) {
                 if ($hk eq 'min_count') {
@@ -166,11 +168,11 @@ sub _execute {
             $param->{min_count} = $min unless $param->{min_count};
             $param->{max_count} = $max unless $param->{max_count};
         }
-    } elsif ($service eq 's3' && __PACKAGE__->awscli_version >= 0.15.0) {
+    } elsif ($service eq 's3' && $self->awscli_version >= 0.15.0) {
         if ($operation !~ /^(?:cp|ls|mb|mv|rb|rm|sync|website)$/) {
             return $self->s3api($operation, @_);
         }
-    } elsif ($service eq 's3api' && __PACKAGE__->awscli_version < 0.15.0) {
+    } elsif ($service eq 's3api' && $self->awscli_version < 0.15.0) {
         return $self->s3($operation, @_);
     }
 

--- a/t/03_awscli_path.t
+++ b/t/03_awscli_path.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use AWS::CLIWrapper;
+
+subtest 'default' => sub {
+  my $cli = AWS::CLIWrapper->new;
+  is $cli->awscli_path, 'aws';
+};
+
+subtest 'specify explicit awscli path' => sub {
+  my $cli = AWS::CLIWrapper->new(awscli_path => '/usr/local/bin/aws');
+  is $cli->awscli_path, '/usr/local/bin/aws';
+};
+
+done_testing;

--- a/t/03_awscli_version.t
+++ b/t/03_awscli_version.t
@@ -3,9 +3,10 @@ use Test::More;
 
 use AWS::CLIWrapper;
 
-ok(AWS::CLIWrapper->awscli_version >= 0);
-if (AWS::CLIWrapper->awscli_version > 0) {
-    ok(AWS::CLIWrapper->awscli_version > 0.001);
+my $cli_wrapper = AWS::CLIWrapper->new;
+ok($cli_wrapper->awscli_version >= 0);
+if ($cli_wrapper->awscli_version > 0) {
+    ok($cli_wrapper->awscli_version > 0.001);
 }
 
 done_testing;

--- a/xt/30_compat.t
+++ b/xt/30_compat.t
@@ -56,7 +56,7 @@ subtest 'ec2 run-instances: --min-count, --max-count VS --count' => sub {
 # <  0.15.0 : s3 only
 subtest 's3 and s3api' => sub {
     plan skip_all => "Suport S3 >= 0.8.0"
-        if AWS::CLIWrapper->awscli_version < 0.8.0;
+        if $aws->awscli_version < 0.8.0;
     # >= 0.15.0
     $res = $aws->s3api('list-buckets');
     ok($res, 's3api list-buckets');
@@ -65,7 +65,7 @@ subtest 's3 and s3api' => sub {
     ok($res, 's3 list-buckets');
 
     $res = $aws->s3('ls');
-    if (AWS::CLIWrapper->awscli_version >= 0.15.0) {
+    if ($aws->awscli_version >= 0.15.0) {
         ok($res, 's3 ls >= 0.15.0');
     } else {
         like($AWS::CLIWrapper::Error->{Message}, qr/invalid choice: 'ls'/, 's3 ls < 0.15.0');


### PR DESCRIPTION
Now we should configure `PATH` to determine which awscli executable used, but it is complicated (and sometimes hard) to treat `PATH` well (e.g. path separator).