### PR TITLE
Fix AWS_CLIWRAPPER_TIMEOUT test

### DIFF
--- a/t/03_awscli_timeout.t
+++ b/t/03_awscli_timeout.t
@@ -4,6 +4,8 @@ use Test::More;
 use AWS::CLIWrapper;
 
 {
+  local $ENV{AWS_CLIWRAPPER_TIMEOUT} = undef;
+
   my $aws = AWS::CLIWrapper->new();
 
   is $aws->{timeout}, 30, "default timeout is 30 seconds";


### PR DESCRIPTION
When building and testing `AWS::CLIWrapper` inside a Docker container with the `AWS_CLIWRAPPER_TIMEOUT` defined, the tests would fail. A minor issue that I worked around in my Dockerfile but still needs fixed.

Thanks!