### PR TITLE
Add `region` method to allow introspection on constructor arguments

### DIFF
--- a/lib/AWS/CLIWrapper.pm
+++ b/lib/AWS/CLIWrapper.pm
@@ -22,6 +22,8 @@ my $AWSCLI_VERSION = undef;
 sub new {
     my($class, %param) = @_;
 
+    my $region = $param{region};
+
     my @opt = ();
     for my $k (qw(region profile endpoint_url)) {
         if (my $v = delete $param{$k}) {
@@ -30,6 +32,7 @@ sub new {
     }
 
     my $self = bless {
+        region => $region,
         opt  => \@opt,
         json => JSON->new,
         awscli_path => $param{awscli_path} || 'aws',
@@ -39,6 +42,8 @@ sub new {
 
     return $self;
 }
+
+sub region { shift->{region} }
 
 sub awscli_path {
     my ($self) = @_;

--- a/t/03_region.t
+++ b/t/03_region.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use AWS::CLIWrapper;
+
+my $cli = AWS::CLIWrapper->new(
+  region => 'us-west-1',
+);
+
+is $cli->region, 'us-west-1', "region ok";
+
+done_testing;


### PR DESCRIPTION
In a scenario when one `AWS::CLIWrapper` object is created at the beginning of the script and passed to various functions subsequently, it is beneficial to be able to introspect the region value passed to `AWS::CLIWrapper` object during construction. This pull request implements a method to allow such introspection.