### PR TITLE
Optionally catch aws-cli errors and retry

### DIFF
--- a/lib/AWS/CLIWrapper.pm
+++ b/lib/AWS/CLIWrapper.pm
@@ -18,6 +18,9 @@ our $true  = do { bless \(my $dummy = 1), "AWS::CLIWrapper::Boolean" };
 our $false = do { bless \(my $dummy = 0), "AWS::CLIWrapper::Boolean" };
 
 my $AWSCLI_VERSION = undef;
+my $DEFAULT_CATCH_ERROR_RETRIES = 3;
+my $DEFAULT_CATCH_ERROR_MIN_DELAY = 3;
+my $DEFAULT_CATCH_ERROR_MAX_DELAY = 10;
 
 sub new {
     my($class, %param) = @_;
@@ -32,6 +35,7 @@ sub new {
     my $self = bless {
         opt  => \@opt,
         json => JSON->new,
+        param => \%param,
         awscli_path => $param{awscli_path} || 'aws',
         croak_on_error => !!$param{croak_on_error},
         timeout => (defined $ENV{AWS_CLIWRAPPER_TIMEOUT}) ? $ENV{AWS_CLIWRAPPER_TIMEOUT} : 30,
@@ -61,6 +65,73 @@ sub awscli_version {
         };
     }
     return $AWSCLI_VERSION;
+}
+
+sub catch_error_pattern {
+    my ($self) = @_;
+
+    return $ENV{AWS_CLIWRAPPER_CATCH_ERROR_PATTERN}
+        if defined $ENV{AWS_CLIWRAPPER_CATCH_ERROR_PATTERN};
+
+    return $self->{param}->{catch_error_pattern}
+        if defined $self->{param}->{catch_error_pattern};
+    
+    return;
+}
+
+sub catch_error_retries {
+    my ($self) = @_;
+
+    my $retries = defined $ENV{AWS_CLIWRAPPER_CATCH_ERROR_RETRIES}
+        ? $ENV{AWS_CLIWRAPPER_CATCH_ERROR_RETRIES}
+        : defined $self->{param}->{catch_error_retries}
+            ? $self->{param}->{catch_error_retries}
+            : $DEFAULT_CATCH_ERROR_RETRIES;
+
+    $retries = $DEFAULT_CATCH_ERROR_RETRIES if $retries < 0;
+
+    return $retries;
+}
+
+sub catch_error_min_delay {
+    my ($self) = @_;
+
+    my $min_delay = defined $ENV{AWS_CLIWRAPPER_CATCH_ERROR_MIN_DELAY}
+        ? $ENV{AWS_CLIWRAPPER_CATCH_ERROR_MIN_DELAY}
+        : defined $self->{param}->{catch_error_min_delay}
+            ? $self->{param}->{catch_error_min_delay}
+            : $DEFAULT_CATCH_ERROR_MIN_DELAY;
+    
+    $min_delay = $DEFAULT_CATCH_ERROR_MIN_DELAY if $min_delay < 0;
+
+    return $min_delay;
+}
+
+sub catch_error_max_delay {
+    my ($self) = @_;
+
+    my $min_delay = $self->catch_error_min_delay;
+
+    my $max_delay = defined $ENV{AWS_CLIWRAPPER_CATCH_ERROR_MAX_DELAY}
+        ? $ENV{AWS_CLIWRAPPER_CATCH_ERROR_MAX_DELAY}
+        : defined $self->{param}->{catch_error_max_delay}
+            ? $self->{param}->{catch_error_max_delay}
+            : $DEFAULT_CATCH_ERROR_MAX_DELAY;
+    
+    $max_delay = $DEFAULT_CATCH_ERROR_MAX_DELAY if $max_delay < 0;
+
+    $max_delay = $min_delay if $min_delay > $max_delay;
+
+    return $max_delay;
+}
+
+sub catch_error_delay {
+    my ($self) = @_;
+
+    my $min = $self->catch_error_min_delay;
+    my $max = $self->catch_error_max_delay;
+
+    return $min == $max ? $min : $min + (int rand $max - $min);
 }
 
 sub param2opt {
@@ -190,12 +261,43 @@ sub _execute {
     @cmd = map { shell_quote($_) } @cmd;
     warn "cmd: ".join(' ', @cmd) if $ENV{AWSCLI_DEBUG};
 
+    my $error_re = $self->catch_error_pattern;
+    my $retries = $error_re ? $self->catch_error_retries : 0;
+
+    RETRY: {
+        $Error = { Message => '', Code => '' };
+
+        my $exit_value = $self->_run(\%opt, \@cmd);
+        my $ret = $self->_handle($service, $operation, $exit_value);
+
+        return $ret unless $Error->{Code};
+
+        if ($retries-- > 0 and $Error->{Message} =~ $error_re) {
+            my $delay = $self->catch_error_delay;
+
+            warn "Caught error matching $error_re, sleeping $delay seconds before retrying\n"
+                if $ENV{AWSCLI_DEBUG};
+
+            sleep $delay;
+
+            redo RETRY;
+        }
+
+        croak $Error->{Message} if $self->{croak_on_error};
+
+        return $ret;
+    }
+}
+
+sub _run {
+    my ($self, $opt, $cmd) = @_;
+
     my $ret;
-    if (exists $opt{'nofork'} && $opt{'nofork'}) {
+    if (exists $opt->{'nofork'} && $opt->{'nofork'}) {
         # better for perl debugger
         my($ok, $err, $buf, $stdout_buf, $stderr_buf) = IPC::Cmd::run(
-            command => join(' ', @cmd),
-            timeout => $opt{timeout} || $self->{timeout},
+            command => join(' ', @$cmd),
+            timeout => $opt->{timeout} || $self->{timeout},
         );
         $ret->{stdout} = join "", @$stdout_buf;
         $ret->{err_msg} = (defined $err ? "$err\n" : "") . join "", @$stderr_buf;
@@ -208,10 +310,16 @@ sub _execute {
         }
         print "";
     } else {
-        $ret = IPC::Cmd::run_forked(join(' ', @cmd), {
-            timeout => $opt{timeout} || $self->{timeout},
+        $ret = IPC::Cmd::run_forked(join(' ', @$cmd), {
+            timeout => $opt->{timeout} || $self->{timeout},
         });
     }
+
+    return $ret;
+}
+
+sub _handle {
+    my ($self, $service, $operation, $ret) = @_;
 
     if ($ret->{exit_code} == 0 && $ret->{timeout} == 0) {
         my $json = $ret->{stdout};
@@ -261,8 +369,6 @@ sub _execute {
                         ) if $ENV{AWSCLI_DEBUG};
             $Error = { Message => $msg, Code => 'Unknown' };
         }
-
-        croak $Error->{Message} if $self->{croak_on_error};
 
         return;
     }
@@ -673,10 +779,15 @@ Constructor of AWS::CLIWrapper. Acceptable AWS CLI params are:
 
 Additionally, the these params can be used to control the wrapper behavior:
 
-    nofork          Truthy to avoid forking when executing `aws`
-    timeout         `aws` execution timeout
-    croak_on_error  Truthy to croak() with the error message when `aws`
-                    exits with non-zero code
+    nofork                  Truthy to avoid forking when executing `aws`
+    timeout                 `aws` execution timeout
+    croak_on_error          Truthy to croak() with the error message when `aws`
+                            exits with non-zero code
+    catch_error_pattern     Regexp pattern to match for error handling.
+    catch_error_retries     Retries for handling errors.
+    catch_error_min_delay   Minimal delay before retrying `aws` call
+                            when an error was caught.
+    catch_error_max_delay   Maximal delay before retrying `aws` call.
 
 See below for more detailed explanation.
 
@@ -1416,6 +1527,46 @@ Third arg "opt" is optional. Available key/values are below:
   croak_on_error => Int (>0)
     When set to a truthy value, this will make AWS::CLIWrapper to croak() with error message when `aws` command exits with non-zero status. Default behavior is to set $AWS::CLIWrapper::Error and return.
 
+  catch_error_pattern => RegExp
+    When defined, this option will enable catching `aws-cli` errors matching this pattern
+    and retrying `aws-cli` command execution. Environment variable
+    AWS_CLIWRAPPER_CATCH_ERROR_PATTERN takes precedence over this option, if both
+    are defined.
+
+    Default is undef.
+
+  catch_error_retries => Int (>= 0)
+    When defined, this option will set the number of retries to make when `aws-cli` error
+    was caught with catch_error_pattern, before giving up. Environment variable
+    AWS_CLIWRAPPER_CATCH_ERROR_RETRIES takes precedence over this option, if both
+    are defined.
+
+    0 (zero) retries is a valid way to turn off error catching via environment variable
+    in certain scenarios. Negative values are invalid and will be reset to default.
+
+    Default is 3.
+
+  catch_error_min_delay => Int (>= 0)
+    When defined, this option will set the minimum delay in seconds before attempting
+    a retry of failed `aws-cli` execution when the error was caught. Environment variable
+    AWS_CLIWRAPPER_CATCH_ERROR_MIN_DELAY takes precedence over this option, if both
+    are defined.
+
+    0 (zero) is a valid value. Negative values are invalid and will be reset to default.
+
+    Default is 3.
+
+  catch_error_max_delay => Int (>= 0)
+    When defined, this option will set the maximum delay in seconds before attempting
+    a retry of failed `aws-cli` execution. Environment variable AWS_CLIWRAPPER_CATCH_ERROR_MAX_DELAY
+    takes precedence over this option, if both are defined.
+
+    0 (zero) is a valid value. Negative values are invalid and will be reset to default.
+    If catch_error_min_delay is greater than catch_error_max_delay, both are set
+    to catch_error_min_delay value.
+
+    Default is 10.
+
 =back
 
 =head1 ENVIRONMENT
@@ -1433,6 +1584,25 @@ If this variable is set, this value will be used instead of default timeout (30 
 invocation of `aws-cli` that does not have a timeout value provided in the options argument of the
 called function.
 
+=item AWS_CLIWRAPPER_CATCH_ERROR_PATTERN
+
+If this variable is set, AWS::CLIWrapper will retry `aws-cli` execution if stdout output
+of failed `aws-cli` command matches the pattern. See L<ERROR HANDLING>.
+
+=item AWS_CLIWRAPPER_CATCH_ERROR_RETRIES
+
+How many times to retry command execution if an error was caught. Default is 3.
+
+=item AWS_CLIWRAPPER_CATCH_ERROR_MIN_DELAY
+
+Minimal delay before retrying command execution if an error was caught, in seconds.
+
+Default is 3.
+
+=item AWS_CLIWRAPPER_CATCH_ERROR_MAX_DELAY
+
+Maximal delay before retrying command execution, in seconds. Default is 10.
+
 =item AWS_CONFIG_FILE
 
 =item AWS_ACCESS_KEY_ID
@@ -1444,6 +1614,35 @@ called function.
 See documents of aws-cli.
 
 =back
+
+=head1 ERROR HANDLING
+
+=over 4
+
+By default, when `aws-cli` exits with an error code (> 0), AWS::CLIWrapper will set
+the error code and message to $AWS::CLIWrapper::Error (and optionally croak), thus
+relaying the error to calling code. While this approach is beneficial 99% of the time,
+in some use cases `aws-cli` execution fails for a temporary reason unrelated to
+both calling code and AWS::CLIWrapper, and can be safely retried after a short delay.
+
+One of this use cases is executing `aws-cli` on AWS EC2 instances, where `aws-cli`
+retrieves its configuration and credentials from the API exposed to the EC2 instance;
+at certain times these credentials may be rotated and calling `aws-cli` at exactly
+the right moment will cause it to fail with `Unable to locate credentials` error.
+
+To prevent this kind of errors from failing the calling code, AWS::CLIWrapper allows
+configuring an RegExp pattern and retry `aws-cli` execution if it fails with an error
+matching the configured pattern.
+
+The error catching pattern, as well as other configuration, can be defined either
+as AWS::CLIWrapper options in the code, or as respective environment variables
+(see L<ENVIRONMENT>).
+
+The actual delay before retrying a failed `aws-cli` execution is computed as a
+random value of seconds between catch_error_min_delay (default 3) and catch_error_max_delay
+(default 10). Backoff is not supported at this moment.
+
+=back 
 
 =head1 AUTHOR
 

--- a/t/05_catch_error_options.t
+++ b/t/05_catch_error_options.t
@@ -1,0 +1,208 @@
+use 5.008001;
+use strict;
+use warnings;
+no warnings 'uninitialized';
+
+use Test::More;
+use AWS::CLIWrapper;
+
+my %default_args = (
+  awscli_path => 't/bin/mock-aws',
+  nofork => 1,
+);
+
+my $tests = eval join "\n", <DATA> or die "$@";
+
+for my $test_name (keys %$tests) {
+  next if @ARGV and not grep { $_ eq $test_name } @ARGV;
+
+  my $test = $tests->{$test_name};
+  my ($args, $env, $method, $want) = @$test{qw(args env method want)};
+
+  $env = {} unless $env;
+
+  local @ENV{keys %$env} = values %$env;
+
+  my $aws = AWS::CLIWrapper->new(%default_args, %{$args || {}});
+  my $have = $aws->$method;
+
+  if ('ARRAY' eq ref $want) {
+    cmp_ok $have, $_->[0], $_->[1], "$test_name " . (join ' ', @$_) for @$want;
+  }
+  else {
+    is $have, $want, $test_name;
+  }
+}
+
+
+done_testing;
+
+__DATA__
+# line 41
+{
+  'mock-aws version' => {
+    method => 'awscli_version',
+    want => '2.42.4242',
+  },
+  'default-catch_error_pattern' => {
+    method => 'catch_error_pattern',
+    want => undef,
+  },
+  'default-catch_error_retries' => {
+    method => 'catch_error_retries',
+    want => 3,
+  },
+  'default-catch_error_min_delay' => {
+    method => 'catch_error_min_delay',
+    want => 3,
+  },
+  'default-catch_error_max_delay' => {
+    method => 'catch_error_max_delay',
+    want => 10,
+  },
+  'default-catch_error_delay' => {
+    method => 'catch_error_delay',
+    want => [['>=', 3], ['<=', 10]],
+  },
+  'env-catch_error_pattern' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_PATTERN => 'foo',
+    },
+    method => 'catch_error_pattern',
+    want => 'foo',
+  },
+  'env-catch_error_retries' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_RETRIES => 10,
+    },
+    method => 'catch_error_retries',
+    want => 10,
+  },
+  'env-catch_error_retries-invalid' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_RETRIES => -10,
+    },
+    method => 'catch_error_retries',
+    want => 3,
+  },
+  'env-catch_error_min_delay' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_MIN_DELAY => 15,
+    },
+    method => 'catch_error_min_delay',
+    want => 15,
+  },
+  'env-catch_error_min_delay-invalid' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_MIN_DELAY => -15,
+    },
+    method => 'catch_error_min_delay',
+    want => 3,
+  },
+  'env-catch_error_max_delay' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_MAX_DELAY => 30,
+    },
+    method => 'catch_error_max_delay',
+    want => 30,
+  },
+  'env-catch_error_max_delay-invalid' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_MAX_DELAY => -30,
+    },
+    method => 'catch_error_max_delay',
+    want => 10,
+  },
+  'env-catch_error_max_delay-gt-min_delay' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_MIN_DELAY => 30,
+      AWS_CLIWRAPPER_CATCH_ERROR_MAX_DELAY => 15,
+    },
+    method => 'catch_error_max_delay',
+    want => 30,
+  },
+  'args-catch_error_pattern' => {
+    args => {
+      catch_error_pattern => 'bar',
+    },
+    method => 'catch_error_pattern',
+    want => 'bar',
+  },
+  'env-over-args-catch_error_pattern' => {
+    args => {
+      catch_error_pattern => 'qux',
+    },
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_PATTERN => 'baz',
+    },
+    method => 'catch_error_pattern',
+    want => 'baz',
+  },
+  'args-catch_error_retries' => {
+    args => {
+      catch_error_retries => 10,
+    },
+    method => 'catch_error_retries',
+    want => 10,
+  },
+  'env-over-args-catch_error_retries' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_RETRIES => 20,
+    },
+    args => {
+      catch_error_retries => 10,
+    },
+    method => 'catch_error_retries',
+    want => 20,
+  },
+  'args-catch_error_min_delay' => {
+    args => {
+      catch_error_min_delay => 20,
+    },
+    method => 'catch_error_min_delay',
+    want => 20,
+  },
+  'env-over-args-catch_error_min_delay' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_MIN_DELAY => 40,
+    },
+    args => {
+      catch_error_min_delay => 20,
+    },
+    method => 'catch_error_min_delay',
+    want => 40,
+  },
+  'args-catch_error_max_delay' => {
+    args => {
+      catch_error_max_delay => 60,
+    },
+    method => 'catch_error_max_delay',
+    want => 60,
+  },
+  'env-over-args-catch_error_max_delay' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_MAX_DELAY => 120,
+    },
+    args => {
+      catch_error_max_delay => 60,
+    },
+    method => 'catch_error_max_delay',
+    want => 120,
+  },
+  'min-max-catch_error_delay' => {
+    args => {
+      catch_error_min_delay => 30,
+      catch_error_max_delay => 30,
+    },
+    method => 'catch_error_delay',
+    want => 30,
+  },
+  'zero-catch_error_delay' => {
+    args => {
+      catch_error_min_delay => 0,
+      catch_error_max_delay => 0,
+    },
+    method => 'catch_error_delay',
+    want => 0,
+  },
+}

--- a/t/06_catch_errors.t
+++ b/t/06_catch_errors.t
@@ -1,0 +1,133 @@
+use 5.008001;
+use strict;
+use warnings;
+no warnings 'uninitialized';
+
+use Test::More;
+use File::Temp 'tempfile';
+
+use AWS::CLIWrapper;
+
+my %default_wrapper_args = (
+  awscli_path => 't/bin/mock-aws',
+  nofork => 1,
+);
+
+my $tests = eval join "\n", <DATA> or die "$@";
+
+for my $test_name (keys %$tests) {
+  next if @ARGV and not grep { $_ eq $test_name } @ARGV;
+
+  my $test = $tests->{$test_name};
+  my ($wrapper_args, $env, $command, $subcommand, $cmd_args)
+    = @$test{qw(wrapper_args env command subcommand cmd_args)};
+  
+  $env = {} unless $env;
+
+  my ($tmp_fh, $tmp_name) = tempfile;
+  print $tmp_fh $test->{retries} || 1;
+  close $tmp_fh;
+
+  local $ENV{AWS_CLIWRAPPER_TEST_ERROR_COUNTER_FILE} = $tmp_name;
+  local $ENV{AWS_CLIWRAPPER_TEST_DIE_WITH_ERROR} = $test->{error_to_die_with}
+    if $test->{error_to_die_with};
+  
+  local @ENV{keys %$env} = values %$env;
+  
+  $AWS::CLIWrapper::Error = { Message => '', Code => '' };
+
+  my $aws = AWS::CLIWrapper->new(%default_wrapper_args, %{$wrapper_args || {}});
+  my $res = eval { $aws->$command($subcommand, @{$cmd_args || []}) };
+
+  if ($test->{retries} > 0) {
+    open my $fh, "<", $tmp_name;
+    my $counter = <$fh>;
+    close $fh;
+
+    is $counter, 0, "$test_name retry counter exhausted";
+  }
+
+  like "$@", $test->{exception}, "$test_name exception";
+  like $AWS::CLIWrapper::Error->{Message}, $test->{error_msg_re},
+    "$test_name error message";
+
+  is_deeply $res, $test->{want}, "$test_name result";
+}
+
+done_testing;
+
+__DATA__
+# line 60
+{
+  'no-error' => {
+    command => 'ecs',
+    subcommand => 'list-clusters',
+    error_to_die_with => undef,
+    error_msg_re => qr{^$},
+    exception => qr{^$},
+    want => {
+      clusterArns => [
+        "arn:aws:ecs:us-foo-1:123456789:cluster/foo",
+        "arn:aws:ecs:us-foo-1:123456789:cluster/bar",
+        "arn:aws:ecs:us-foo-1:123456789:cluster/baz"
+      ],
+    }
+  },
+  'no-croak' => {
+    command => 'ecs',
+    subcommand => 'list-clusters',
+    error_to_die_with => 'uh-oh',
+    error_msg_re => qr{uh-oh},
+    exception => qr{^$},
+    want => undef,
+  },
+  'with-croak' => {
+    wrapper_args => { croak_on_error => 1 },
+    command => 'ecs',
+    subcommand => 'list-clusters',
+    error_to_die_with => 'foobaroo!',
+    error_msg_re => qr{foobaroo},
+    exception => qr{foobaroo},
+    want => undef,
+  },
+  'catch-no-croak' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_PATTERN => 'FUBAR',
+      AWS_CLIWRAPPER_CATCH_ERROR_MIN_DELAY => 0,
+      AWS_CLIWRAPPER_CATCH_ERROR_MAX_DELAY => 0,
+    },
+    command => 'ecs',
+    subcommand => 'list-clusters',
+    error_to_die_with => 'FUBAR',
+    retries => 2,
+    error_msg_re => qr{^$},
+    exception => qr{^$},
+    want => {
+      clusterArns => [
+        "arn:aws:ecs:us-foo-1:123456789:cluster/foo",
+        "arn:aws:ecs:us-foo-1:123456789:cluster/bar",
+        "arn:aws:ecs:us-foo-1:123456789:cluster/baz"
+      ],
+    }
+  },
+  'catch-with-croak' => {
+    env => {
+      AWS_CLIWRAPPER_CATCH_ERROR_PATTERN => 'throbbe',
+      AWS_CLIWRAPPER_CATCH_ERROR_MIN_DELAY => 0,
+      AWS_CLIWRAPPER_CATCH_ERROR_MAX_DELAY => 0,
+    },
+    command => 'ecs',
+    subcommand => 'list-clusters',
+    error_to_die_with => 'zong throbbe fung',
+    retries => 3,
+    error_msg_re => qr{^$},
+    exception => qr{^$},
+    want => {
+      clusterArns => [
+        "arn:aws:ecs:us-foo-1:123456789:cluster/foo",
+        "arn:aws:ecs:us-foo-1:123456789:cluster/bar",
+        "arn:aws:ecs:us-foo-1:123456789:cluster/baz"
+      ],
+    }
+  },
+}

--- a/t/bin/mock-aws
+++ b/t/bin/mock-aws
@@ -1,0 +1,89 @@
+#!/usr/bin/perl
+
+eval 'exec /usr/bin/perl -wS $0 ${1+"$@"}'
+  if 0;
+
+use strict;
+use warnings;
+no warnings 'uninitialized';
+
+version() if $ARGV[0] eq "--version";
+
+handle_die_with_error() if $ENV{AWS_CLIWRAPPER_TEST_DIE_WITH_ERROR};
+
+my $cmd = shift @ARGV;
+my $subcmd = shift @ARGV;
+
+handle($cmd, $subcmd);
+
+sub handle {
+  my ($cmd, $subcmd) = @_;
+
+  $subcmd =~ s/-/_/g;
+
+  my $handler = do {
+    no strict 'refs';
+
+    *{"main::${cmd}_$subcmd"}{CODE};
+  };
+
+  if ('CODE' eq ref $handler) {
+    $handler->();
+
+    exit 0;
+  }
+  else {
+    help();
+  }
+}
+
+sub handle_die_with_error {
+  my $counter_file = $ENV{AWS_CLIWRAPPER_TEST_ERROR_COUNTER_FILE};
+
+  return unless -f $counter_file;
+
+  open my $fh, "<", $counter_file or die "Cannot open $counter_file for read: $!";
+  my $counter = <$fh>;
+  close $fh;
+
+  # This logic is the opposite of usual retries: we throw an error for the counter
+  # number of times and then proceed normally after.
+  if ($counter-- > 0) {
+    open $fh, ">", $counter_file or die "Cannot open $counter_file for write: $!";
+    print $fh $counter;
+    close $fh;
+
+    die $ENV{AWS_CLIWRAPPER_TEST_DIE_WITH_ERROR};
+  }
+}
+
+sub version {
+  print "aws-cli/2.42.4242\n";
+  exit 0;
+}
+
+sub help {
+    die <<__END__;
+usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
+To see help text, you can run:
+
+  aws help
+  aws <command> help
+  aws <command> <subcommand> help
+
+aws: error: the following arguments are required: operation
+
+__END__
+}
+
+sub ecs_list_clusters {
+    print <<__END__;
+{
+    "clusterArns": [
+        "arn:aws:ecs:us-foo-1:123456789:cluster/foo",
+        "arn:aws:ecs:us-foo-1:123456789:cluster/bar",
+        "arn:aws:ecs:us-foo-1:123456789:cluster/baz"
+    ]
+}
+__END__
+}


### PR DESCRIPTION
There is a class of `aws` errors that are transient and can be safely retried after a short delay. Handling these errors in calling code can be awkward, and is better done in AWS::CLIWrapper. This PR implements optional error handling in CLIWrapper.

Configuration can be done either via options or environment variables, with env taking precedence.

I've refactored `_execute` method a bit, hopefully this is self explanatory. The pod is updated with the relevant documentation.

Testing the error catching is done via executing mock `aws` program. I've been itching to add this mock for quite some time, hopefully we can use it for more testing going forward.

Tests themselves might be a bit dense to parse at the first blush, I'm using the data driven pattern that I've worked out years ago to save the amount of test code I need to write. Please let me know if you have any questions.